### PR TITLE
fix: creating biased random numbers from a cryptographically secure source

### DIFF
--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -36,7 +36,16 @@ export function generateUniqueHtmlId(prefix = 'dnbuid', length = 16): string {
  * Create a random string of the specified length
  */
 export function generateRandomString(len: number): string {
-  return Array.from(crypto.getRandomValues(new Uint8Array(len)))
-    .map((n) => (n % 36).toString(36))
-    .join('');
+  const chars = [];
+  const charsetLen = 36;
+  const maxMultiple = Math.floor(256 / charsetLen) * charsetLen; // 252
+  while (chars.length < len) {
+    const arr = new Uint8Array(1);
+    crypto.getRandomValues(arr);
+    const n = arr[0];
+    if (n < maxMultiple) {
+      chars.push((n % charsetLen).toString(36));
+    }
+  }
+  return chars.join('');
 }


### PR DESCRIPTION
Potential fix for [https://github.com/davidsneighbour/kollitsch.dev/security/code-scanning/62](https://github.com/davidsneighbour/kollitsch.dev/security/code-scanning/62)

To fix the issue, we should generate random string characters without introducing bias. The best method is to use a rejection-sampling approach: For each random byte, only use its value if it is less than the largest multiple of 36 less than 256, i.e., 252. Discard bytes with values 252–255 and draw a new random byte, ensuring each character is generated from an unbiased random number between 0 and 35. Alternatively, we can use a well-vetted library (like `crypto-random-string`) if available in the project's context, but since only built-in APIs are used here, we'll implement rejection sampling ourselves. We should add a helper for random base36 generation, or rework `generateRandomString` to safely and unbiasedly select each character from a set of 36 (0..9, a..z).

The following should be changed in `src/utils/helpers.ts`:
- Update the implementation of `generateRandomString` to use rejection sampling for every character to avoid bias.
- We'll need to slightly refactor the function, but the signature and intention remain unchanged.
- Ensure that the code works in the browser with `crypto.getRandomValues`.

No new imports are required, and implementation stays in the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
