### PR TITLE
fix: prototype-polluting function

### DIFF
--- a/src/packages/generate-package.ts
+++ b/src/packages/generate-package.ts
@@ -95,6 +95,10 @@ function parseArgs(): Options {
  */
 function mergeDeep<T>(target: T, source: Partial<T>): T {
   for (const key of Object.keys(source)) {
+    // Prevent prototype pollution by skipping dangerous keys
+    if (key === "__proto__" || key === "constructor" || key === "prototype") {
+      continue;
+    }
     // Use type assertion to allow string indexing on Partial<T> and T
     const sv = (source as Record<string, any>)[key];
     const tv = (target as Record<string, any>)[key];


### PR DESCRIPTION
Potential fix for [https://github.com/davidsneighbour/kollitsch.dev/security/code-scanning/51](https://github.com/davidsneighbour/kollitsch.dev/security/code-scanning/51)

**How to fix:**  
The safest general approach is to prevent `mergeDeep` from copying keys that could mutate the prototype chain: blacklist the keys `__proto__`, `constructor`, and `prototype`. Additionally, do not descend into these keys when merging recursively.  

**Detailed fix:**  
Edit `mergeDeep` so that, before merging or assigning `target[key] = sv`, we skip any key that equals `"__proto__"`, `"constructor"`, or `"prototype"`. This prevents prototype pollution. You can implement this as a check at the top of the for-loop over keys, using e.g. an if-statement.  

**Exact edits:**  
- Update the `for (const key...` loop in `mergeDeep` in src/packages/generate-package.ts so that it skips `"__proto__"`, `"constructor"`, and `"prototype"` keys.
- All edits are local to the `mergeDeep` function.

**Required methods/imports:**  
No new imports are needed. This can all be done inline using standard JavaScript.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
